### PR TITLE
Changed labels to y vector,passed labels as list

### DIFF
--- a/docs/api/text/tsne.rst
+++ b/docs/api/text/tsne.rst
@@ -20,8 +20,8 @@ After importing the required tools, we can :doc:`load the corpus <corpus>` and v
     corpus = load_corpus('hobbies')
     tfidf  = TfidfVectorizer()
 
-    docs   = tfidf.fit_transform(corpus.data)
-    labels = corpus.target
+    X   = tfidf.fit_transform(corpus.data)
+    y   = corpus.target
 
 Now that the corpus is vectorized we can visualize it, showing the distribution of classes.
 
@@ -29,10 +29,20 @@ Now that the corpus is vectorized we can visualize it, showing the distribution 
 
     # Create the visualizer and draw the vectors
     tsne = TSNEVisualizer()
-    tsne.fit(docs, labels)
+    tsne.fit(X, y)
     tsne.poof()
 
 .. image:: images/tsne_all_docs.png
+
+Now,let's pass on a list of labels to TSNEVisualizer.
+
+.. code:: python
+
+    #Pass on a list of labels
+    labels = corpus.categories
+    tsne = TSNEVisualizer(labels=labels)
+    tsne.fit(X, y)
+    tsne.poof()
 
 If we omit the target during fit, we can visualize the whole dataset to see if any meaningful patterns are observed.
 


### PR DESCRIPTION
In this pr,I have changed the docs and labels to X and y vector in the fit method which created confusion in tsne documentation.
Also,I have passed labels as a list to the TSNEVisualizer(labels=labels). I am attaching the image poofed after passing labels as a list.
fixes #684.
![tsne_projection_with_labels](https://user-images.githubusercontent.com/31562743/52877730-d58eef00-3180-11e9-8a35-33a5154fcd85.png)
